### PR TITLE
refs #2: The plugin output is now batch-mode compatible.

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -30,7 +30,9 @@ dofile("storage.lua")
 dofile("preferences.lua")
 
 function init(plugin)
-    print("[Perspective Tool] Initializing plugin " .. PLUGIN_VERSION)
+    if app.isUIAvailable then
+        print("[Perspective Tool] Initializing plugin " .. PLUGIN_VERSION)
+    end
     plugin_initialize_prefs(plugin)
 
     local config_dialog = Dialog{title="Perspective Tool"}

--- a/src/preferences.lua
+++ b/src/preferences.lua
@@ -10,7 +10,9 @@ function plugin_initialize_prefs(plugin)
             plugin.preferences["storage_type"] = DEFAULT_STORAGE_TYPE
             plugin.preferences["storage_path"] = DEFAULT_STORAGE_PATH
             plugin.preferences["preview_auto_update"] = DEFAULT_PREVIEW_AUTO_UPDATE
-            print("[Perspective Tool] Preferences initialized")
+            if app.isUIAvailable then
+                print("[Perspective Tool] Preferences initialized")
+            end
             break
         end
     end


### PR DESCRIPTION
This commit should fix the issue raised by @guga2112 about the plugin spitting init strings in batch mode.

I conditioned these strings to the plugin running in the GUI, thus excluding them when invoked from the CLI.
I may have ignored the goal of these strings, so feel free to provide feedback if I missed something.

Thanks